### PR TITLE
chore: bump version to 0.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ The Fedimint UI enables you to administer your Guardian from the browser. Once y
 Using Docker Desktop is a quick and easy way to get started. Run the following commands:
 
 ```bash
-docker image pull --platform linux/amd64 fedibtc/fedimint-ui:0.6.2
+docker image pull --platform linux/amd64 fedibtc/fedimint-ui:0.6.3
 ```
 
 ```bash
-docker run -p 3000:3000 --platform linux/amd64 fedibtc/fedimint-ui:0.6.2
+docker run -p 3000:3000 --platform linux/amd64 fedibtc/fedimint-ui:0.6.3
 ```
 
 The `--platform linux/amd64` flag is typically only required if you're using a Mac with an M chip.

--- a/apps/router/src/constants/index.tsx
+++ b/apps/router/src/constants/index.tsx
@@ -1,2 +1,2 @@
 export const LOCAL_STORAGE_APP_STATE_KEY = 'fedimint_ui_state_v2';
-export const LATEST_RELEASE_TAG = 'v0.6.2';
+export const LATEST_RELEASE_TAG = 'v0.6.3';

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
         # Used for a releasable build artifact 
         packages.guardian-ui = pkgs.stdenv.mkDerivation {
           pname = "guardian-ui";
-          version = "0.6.2";
+          version = "0.6.3";
           src = ./.;
 
           nativeBuildInputs = with pkgs; [


### PR DESCRIPTION
Bump version to 0.6.3 for unique tags