### PR TITLE
Replace "Reset to Consensus" with confirmation modal

### DIFF
--- a/apps/router/src/guardian-ui/components/dashboard/tabs/meta/manager/MetaManager.tsx
+++ b/apps/router/src/guardian-ui/components/dashboard/tabs/meta/manager/MetaManager.tsx
@@ -1,5 +1,19 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Box, Button, Divider, Flex, Link, Text } from '@chakra-ui/react';
+import {
+  Box,
+  Button,
+  Divider,
+  Flex,
+  Link,
+  Text,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  useDisclosure,
+} from '@chakra-ui/react';
 import { fieldsToMeta, metaToHex, useTranslation } from '@fedimint/utils';
 import { ParsedConsensusMeta } from '@fedimint/types';
 import { DEFAULT_META_KEY } from '../../FederationTabsCard';
@@ -34,6 +48,7 @@ export const MetaManager = React.memo(function MetaManager({
   const api = useGuardianAdminApi();
   const [sites, setSites] = useState<string>('[]');
   const [customMeta, setCustomMeta] = useState<Record<string, string>>({});
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   useEffect(() => {
     if (consensusMeta?.value) {
@@ -101,7 +116,8 @@ export const MetaManager = React.memo(function MetaManager({
       setSites(sites || '[]');
       setCustomMeta(rest);
     }
-  }, [consensusMeta]);
+    onClose();
+  }, [consensusMeta, onClose]);
 
   const proposeMetaEdits = useCallback(() => {
     if (metaModuleId === undefined || isAnyFieldEmpty()) return;
@@ -166,13 +182,44 @@ export const MetaManager = React.memo(function MetaManager({
               )}
         </Button>
         {consensusMeta?.value && !isMetaUnchanged() && (
-          <Button onClick={resetToConsensus}>
+          <Button
+            colorScheme='red'
+            bg='red.500'
+            _hover={{ bg: 'red.600' }}
+            onClick={onOpen}
+          >
             {t(
               'federation-dashboard.config.manage-meta.reset-to-consensus-button'
             )}
           </Button>
         )}
       </Flex>
+
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>
+            {t(
+              'federation-dashboard.config.manage-meta.cancel-proposal-modal.title'
+            )}
+          </ModalHeader>
+          <ModalBody>
+            <Text>
+              {t(
+                'federation-dashboard.config.manage-meta.cancel-proposal-modal.description'
+              )}
+            </Text>
+          </ModalBody>
+          <ModalFooter>
+            <Button variant='ghost' mr={3} onClick={onClose}>
+              {t('common.cancel')}
+            </Button>
+            <Button colorScheme='red' onClick={resetToConsensus}>
+              {t('common.confirm')}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
     </Flex>
   );
 });

--- a/apps/router/src/languages/en.json
+++ b/apps/router/src/languages/en.json
@@ -122,6 +122,10 @@
           "title": "Confirm Approval",
           "description": "Your approval will reach the threshold to adopt this meta change. Your new meta will look like:"
         },
+        "cancel-proposal-modal": {
+          "title": "Confirm Cancellation",
+          "description": "Are you sure you want to cancel this proposal?"
+        },
         "consensus-meta-label": "Consensus Metadata",
         "revoke-button": "Revoke",
         "no-consensus-meta-message": "there are no meta in consensus",
@@ -130,7 +134,7 @@
         "propose-new-meta-button": "Propose New Metadata",
         "update-meta-button": "Update Metadata",
         "add-custom-field-button": "Add Custom Field",
-        "reset-to-consensus-button": "Reset to Consensus",
+        "reset-to-consensus-button": "Cancel Proposal",
         "proposal-approved": "You have approved this proposal",
         "no-submitted-meta-message": "there are no meta edits to review",
         "edit-meta-label": "Edit meta",


### PR DESCRIPTION
Issue #659 

Updates misleading button text and adds confirmation flow as requested.

**Changes:**
- Button: "Reset to Consensus" → "Cancel Proposal" (red styling)
- Added confirmation modal to prevent accidental resets
- EN translations only

**Before:**
<img width="1692" height="912" alt="image" src="https://github.com/user-attachments/assets/3c15bb57-30f9-4a8e-8ea2-1c631a835665" />

**After:**
<img width="1718" height="924" alt="image" src="https://github.com/user-attachments/assets/9b42bc2c-4901-4e54-9cc0-f4e20a202614" />

<img width="1714" height="924" alt="image" src="https://github.com/user-attachments/assets/d0de9510-a558-4bf2-b19b-da297fd0bb41" />
